### PR TITLE
Rename gesturedeck android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -46,5 +46,5 @@ android {
 }
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation project(path: ':gesturedeck_sdk')
+    implementation project(path: ':gesturedeck-android')
 }

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,3 +1,3 @@
 rootProject.name = 'gesturedeck_flutter'
-include ':gesturedeck_sdk'
-project(":gesturedeck_sdk").projectDir = file("../../gesturedeck_sdk_android/gesturedeck_sdk")
+include ':gesturedeck-android'
+project(":gesturedeck-android").projectDir = file("../../gesturedeck_sdk_android/gesturedeck-android")

--- a/android/src/main/kotlin/com/navideck/gesturedeck_flutter/GesturedeckFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/navideck/gesturedeck_flutter/GesturedeckFlutterPlugin.kt
@@ -5,8 +5,8 @@ import android.os.Build
 import android.view.KeyEvent
 import android.view.MotionEvent
 import android.view.WindowManager
-import com.navideck.gesturedeck_sdk.Gesturedeck
-import com.navideck.gesturedeck_sdk.model.GesturedeckEvent
+import com.navideck.gesturedeck_android.Gesturedeck
+import com.navideck.gesturedeck_android.model.GesturedeckEvent
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.embedding.engine.renderer.FlutterRenderer
 import io.flutter.plugin.common.*

--- a/config.json
+++ b/config.json
@@ -1,0 +1,4 @@
+{
+    "openai_key": "",
+    "modules": []
+}

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -10,5 +10,5 @@ def flutterSdkPath = properties.getProperty("flutter.sdk")
 assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
 apply from: "$flutterSdkPath/packages/flutter_tools/gradle/app_plugin_loader.gradle"
 
-include ':gesturedeck_sdk'
-project(":gesturedeck_sdk").projectDir = file("../../../gesturedeck_sdk_android/gesturedeck_sdk")
+include ':gesturedeck-android'
+project(":gesturedeck-android").projectDir = file("../../../gesturedeck_sdk_android/gesturedeck-android")


### PR DESCRIPTION
@fotiDim i think last fixes related to `gesturedeck-android` were pushed into [this](https://github.com/Navideck/gesturedeck_sdk_flutter/pull/3) pr , and not merged into main , 
so this Pr is for required fixes only